### PR TITLE
Additional PIPELINE_CSS and PIPELINE_JS can be specified in apps (#197)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -174,6 +174,41 @@ Other settings
 
   Defaults to ``"_"``
 
+``PIPELINE_APP_MODULE``
+.......................
+
+  The name of the app module where Pipeline will look for additional ``PIPELINE_CSS``
+  and ``PIPELINE_JS`` group rules.
+
+  If empty or ``None``, Pipeline will not look for additional group rules within the apps.
+
+  Defaults to ``"compressed"``.
+
+.. note::
+
+  Please do not use ``"pipeline "`` as it will interfere with the Pipeline app name.
+
+``PIPELINE_NAMESPACE_APPS``
+...........................
+
+  If ``True``, Pipeline will namespace all of the group rules defined within the
+  apps according to the ``PIPELINE_NAMESPACE_FORMULA`` setting. This allows to avoid
+  group name collisions between the apps.
+
+  Defaults to ``True``.
+
+``PIPELINE_NAMESPACE_FORMULA``
+..............................
+
+  The format of how the key of the group rule will be formatted within the apps.
+  The value should be specified using
+  `Python's String Formatting <http://docs.python.org/2/library/string.html#formatstrings>`_
+  with the keyword arguments ``app_label`` and ``group_key``. For example, if using the
+  default value, the group key ``"stats"`` within the app ``"foo"`` will become
+  ``"foo_stats"``.
+
+  Defaults to ``"{app_label}_{group_key}"``.
+
 
 Embedding fonts and images
 ==========================

--- a/pipeline/conf/__init__.py
+++ b/pipeline/conf/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import sys
-
 from django.conf import settings as _settings
+
+from .utils import get_app_modules, get_groups
+
 
 DEFAULTS = {
     'DEBUG': False,
@@ -18,6 +19,10 @@ DEFAULTS = {
     'PIPELINE_CSS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
     'PIPELINE_JS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
     'PIPELINE_COMPILERS': [],
+
+    'PIPELINE_APP_MODULE': 'compressed',
+    'PIPELINE_NAMESPACE_APPS': True,
+    'PIPELINE_NAMESPACE_FORMULA': '{app_label}_{group_key}',
 
     'PIPELINE_CSS': {},
     'PIPELINE_JS': {},
@@ -93,3 +98,14 @@ class PipelineSettings(object):
             raise AttributeError("'%s' setting not found" % name)
 
 settings = PipelineSettings(_settings)
+
+
+if settings.PIPELINE_APP_MODULE:
+    for app in get_app_modules():
+        groups = get_groups(app,
+                            settings.PIPELINE_APP_MODULE,
+                            settings.PIPELINE_NAMESPACE_APPS,
+                            settings.PIPELINE_NAMESPACE_FORMULA)
+
+        settings.PIPELINE_CSS.update(groups['css'])
+        settings.PIPELINE_JS.update(groups['js'])

--- a/pipeline/conf/utils.py
+++ b/pipeline/conf/utils.py
@@ -1,0 +1,77 @@
+from __future__ import unicode_literals
+
+from django.db.models.loading import get_apps
+from django.utils.importlib import import_module
+
+
+def get_app_module(app):
+    """
+    Get the actual app module. This is similar to Django's ``get_app`` function from
+    ``django.db.models.loading.get_app`` however instead of returning the model's
+    module, this function returns the actual app module.
+    """
+    return import_module(app.__name__.rsplit('.', 1)[0])
+
+
+def get_app_modules():
+    """
+    Get modules of all installed apps. This is similar to Django's ``get_apps`` function
+    from ``django.db.models.loading.get_apps`` however instead of returning the model's
+    modules, this function returns modules of the actual app.
+    """
+    return [get_app_module(app) for app in get_apps()]
+
+
+def get_app_label(app_module):
+    """
+    Get the app label name from the app module
+    """
+    return app_module.__name__.rsplit('.', 1)[-1]
+
+
+def get_module_from_package(package, module, default=None):
+    """
+    Return the specified module from the given package.
+    """
+    try:
+        return import_module('{0}.{1}'.format(package.__name__, module))
+    except ImportError:
+        return default
+
+
+def get_groups(app_module,
+               pipeline_module,
+               namespace,
+               namespace_format):
+    """
+    Return all the groups from the app pipeline module. This function also
+    renames the group keys if necessary so the output of this function can
+    safely be merged (``dict.update``) with the main project pipeline
+    settings.
+    """
+    pipeline_module = get_module_from_package(app_module, pipeline_module)
+
+    if not pipeline_module:
+        return {
+            'css': {},
+            'js': {},
+        }
+
+    css = getattr(pipeline_module, 'PIPELINE_CSS', {})
+    js = getattr(pipeline_module, 'PIPELINE_JS', {})
+
+    if namespace:
+        app_label = get_app_label(app_module)
+
+        css_keys = [namespace_format.format(app_label=app_label, group_key=key)
+                    for key in css.keys()]
+        js_keys = [namespace_format.format(app_label=app_label, group_key=key)
+                   for key in js.keys()]
+
+        css = dict(zip(css_keys, css.values()))
+        js = dict(zip(js_keys, js.values()))
+
+    return {
+        'css': css,
+        'js': js,
+    }

--- a/tests/compressed.py
+++ b/tests/compressed.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+
+PIPELINE_CSS = {
+    'additional': {
+        'source_filenames': (
+            'pipeline/css/first.css',
+        ),
+        'output_filename': 'additional.css'
+    }
+}
+PIPELINE_JS = {
+    'additional': {
+        'source_filenames': (
+            'pipeline/js/first.js',
+        ),
+        'output_filename': 'additional.css'
+    }
+}

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -5,5 +5,6 @@ from .test_template import *
 from .test_glob import *
 from .test_middleware import *
 from .test_packager import *
+from .test_settings import *
 from .test_storage import *
 from .test_utils import *

--- a/tests/tests/test_settings.py
+++ b/tests/tests/test_settings.py
@@ -1,0 +1,77 @@
+from __future__ import unicode_literals, print_function
+
+from django.test import TestCase
+from pipeline.conf import settings as pipeline_settings
+from pipeline.conf.utils import get_groups
+from tests import compressed
+import imp
+import tests
+
+# The following imports the Django project settings module.
+# Since pipeline will modify the attributes within that module,
+# in order to test if pipeline did anything, the settings module
+# is directly imported (which will contain the updates)
+# Then that module is reloaded which will effectivelly reset
+# it to its default state.
+# Note: In order to be able to reload the module, the module
+# is imported directly as compared to
+# ``from django.conf import settings`` since that imports
+# settings as a lazy object.
+from tests import settings as original_settings
+
+
+# reload the settings to get the original
+original_settings = imp.reload(original_settings)
+
+
+class SettingsTest(TestCase):
+    def test_additional_apps(self):
+        """
+        Test that extra groups were indeed loaded into pipeline settings.
+        """
+        for attr in ['css', 'js']:
+            attr = 'PIPELINE_{0}'.format(attr.upper())
+            self.assertNotEqual(
+                len(getattr(pipeline_settings, attr)),
+                len(getattr(original_settings, attr)),
+            )
+
+            self.assertEqual(
+                len(getattr(pipeline_settings, attr)),
+                len(getattr(original_settings, attr)) + len(getattr(compressed, attr)),
+            )
+
+    def test_get_groups(self):
+        """
+        Test that given an app module, ``get_groups`` returns correct
+        group configurations.
+        """
+        app_module = tests
+        pipeline_module = 'compressed'
+        namespace = False
+        namespace_format = '{app_label}_{group_key}'
+
+        groups = get_groups(app_module,
+                            pipeline_module,
+                            namespace,
+                            namespace_format)
+
+        for i in ['css', 'js']:
+            attr = 'PIPELINE_{0}'.format(i.upper())
+            self.assertEqual(groups[i].keys(),
+                             getattr(compressed, attr).keys())
+
+        namespace = True
+        groups = get_groups(app_module,
+                            pipeline_module,
+                            namespace,
+                            namespace_format)
+
+        for i in ['css', 'js']:
+            attr = 'PIPELINE_{0}'.format(i.upper())
+            self.assertNotEqual(groups[i].keys(),
+                                getattr(compressed, attr).keys())
+
+            keys = [namespace_format.format(app_label='tests', group_key=key)
+                    for key in getattr(compressed, attr).keys()]
+            self.assertEqual(list(groups[i].keys()), keys)


### PR DESCRIPTION
In this pull request I implemented the ability to specify additional PIPELINE_CSS and PIPELINE_JS settings within individual apps within a specified module (default is `compressed` to avoid name collision with `pipeline`).

For example, if you have the following global (within the project settings) `PIPELINE_CSS`:

```
# django settings.py
PIPELINE_CSS = {
    'colors': {
        'source_filenames': (
          'css/core.css',
          'css/colors/*.css',
          'css/layers.css'
        ),
        'output_filename': 'css/colors.css',
        'extra_context': {
            'media': 'screen,projection',
        },
    },
}
```

And you have an app called `fooapp`, you can add a module `compressed` (file `compressed.py`) within the app with the following:

```
# compressed.py within the app
PIPELINE_CSS = {
    'rainbows': {
        'source_filenames': (
            'css/rainbow.css',
        ),
        'output_filename': 'css/rainbow.css',
    },
}
```

Which will result in the following equivalent global setting:

```
# global equivalent
PIPELINE_CSS = {
    'colors': {
        'source_filenames': (
          'css/core.css',
          'css/colors/*.css',
          'css/layers.css'
        ),
        'output_filename': 'css/colors.css',
        'extra_context': {
            'media': 'screen,projection',
        },
    },
    'fooapp_rainbows': {
        'source_filenames': (
            'css/rainbow.css',
        ),
        'output_filename': 'css/rainbow.css',
    },
}
```

The rational of using a Python module instead of let's say a `json` file is that a Python file allows to add some custom logic which a static file would not allow. For the example, the following becomes possible:

```
# compressed.py within the app
from django.conf import settings
PIPELINE_CSS = {
    'rainbows': {
        'source_filenames': (
            'css/rainbow{}.css'.format('_debug' if settings.DEBUG else ''),
        ),
        'output_filename': 'css/rainbow.css',
    },
}
```

This implementation also allows to customize its functionality by using the following new settings:

* `PIPELINE_APP_MODULE` - the name of the module where the `PIPELINE_CSS` and `PIPELINE_JS` will be searched for
* `PIPELINE_NAMESPACE_APPS` - if the key/name of the group rule should be namespaced under an app to avoid name-collisions. The first example above renamed/namespaced the group from `raindows` to `fooapp_rainbows`.
* `PIPELINE_NAMESPACE_FORMULA` - the exact formula of how the group key should be renamed

Also within the commit are updates to the docs as well as some sanity unittests.

**Note:** This is same functionality as pull request [218](https://github.com/cyberdelia/django-pipeline/pull/218) however its refactored to a newer pipeline version.