### PR TITLE
Add missing ignore_pattern to FileSystemFinder.

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -77,6 +77,7 @@ class FileSystemFinder(PatternFilterMixin, FileSystemFinder):
     """
     ignore_patterns = [
         '*.js',
+        '*.css',
         '*.less',
         '*.scss',
         '*.sh',

--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -97,4 +97,5 @@ class FileSystemFinder(PatternFilterMixin, FileSystemFinder):
         '*demo*',
         'Makefile*',
         'Gemfile*',
+        'node_modules',
     ]


### PR DESCRIPTION
Some third party js/css libraries installed through bower, contain
broken references in CSS: url(...). When using PipelineCachedStorage,
this breaks during collectstatic. As with AppDirectoriesFinder, ignore
CSS. CSS is a pielinable content that can be managed through a
pipeline asset.

This brings FileSystemFinder inline with AppDirectoriesFinder.

True, these CSS fixes should be fixed in their respective
projects. Bugs have been filed, but this fix will allow pipeline users
to continue using third party libraries without breaking builds and
deployment.