### PR TITLE
Adding rCSSmin to the default compressors

### DIFF
--- a/docs/compressors.rst
+++ b/docs/compressors.rst
@@ -220,6 +220,14 @@ command to compress stylesheets. To use it, add this to your ``PIPELINE_CSS_COMP
   Additional arguments to use when cssmin is called.
 
   Default to ``''``
+  
+rCSSmin compressor
+=================
+
+The rCSSmin compressor uses the `rCSSmin <https://github.com/ndparker/rcssmin>`_
+package to compress stylesheets. To use it, add this to your ``PIPELINE_CSS_COMPRESSOR`` ::
+
+  PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.rcssmin.RCSSMinCompressor'
 
 No-Op Compressors
 =================

--- a/pipeline/compressors/rcssmin.py
+++ b/pipeline/compressors/rcssmin.py
@@ -1,0 +1,6 @@
+from pipeline.compressors import CompressorBase
+from rcssmin import cssmin
+
+class RCSSMinCompressor(CompressorBase):
+  def compress_css(self, css):
+    return cssmin(css)


### PR DESCRIPTION
rCSSmin is much more memory efficient than the default compressors, is fast, is a Python package, and absolutely straightforward to use.