### PR TITLE
Add ES6 support via 6to5.

### DIFF
--- a/docs/compilers.rst
+++ b/docs/compilers.rst
@@ -144,6 +144,34 @@ To use it add this to your ``PIPELINE_COMPILERS`` ::
   Defaults to ``''``.
 
 
+ES6 compiler
+============
+
+The ES6 compiler uses `6to5 <https://6to5.org>`_
+to convert ES6+ code into vanilla ES5.
+
+To use it add this to your ``PIPELINE_COMPILERS`` ::
+
+  PIPELINE_COMPILERS = (
+      'pipeline.compilers.es6.ES6Compiler',
+  )
+
+
+``PIPELINE_6TO5_BINARY``
+--------------------------
+
+  Command line to execute for 6to5 program.
+  You will most likely change this to the location of 6to5 on your system.
+
+  Defaults to ``'/usr/bin/env 6to5'``.
+
+``PIPELINE_6TO5_ARGUMENTS``
+-----------------------------
+
+  Additional arguments to use when 6to5 is called.
+
+  Defaults to ``''``.
+
 
 Write your own compiler class
 =============================

--- a/pipeline/compilers/es6.py
+++ b/pipeline/compilers/es6.py
@@ -1,0 +1,22 @@
+from __future__ import unicode_literals
+
+from pipeline.conf import settings
+from pipeline.compilers import SubProcessCompiler
+
+
+class ES6Compiler(SubProcessCompiler):
+    output_extension = 'js'
+
+    def match_file(self, path):
+        return path.endswith('.es6')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return  # File doesn't need to be recompiled
+        command = "%s %s %s -o %s" % (
+            settings.PIPELINE_6TO5_BINARY,
+            settings.PIPELINE_6TO5_ARGUMENTS,
+            infile,
+            outfile
+        )
+        return self.execute_command(command)

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -48,6 +48,9 @@ DEFAULTS = {
     'PIPELINE_COFFEE_SCRIPT_BINARY': '/usr/bin/env coffee',
     'PIPELINE_COFFEE_SCRIPT_ARGUMENTS': '',
 
+    'PIPELINE_6TO5_BINARY': '/usr/bin/env 6to5',
+    'PIPELINE_6TO5_ARGUMENTS': '',
+
     'PIPELINE_LIVE_SCRIPT_BINARY': '/usr/bin/env lsc',
     'PIPELINE_LIVE_SCRIPT_ARGUMENTS': '',
 


### PR DESCRIPTION
This allow to use [6to5](http://6to5.org), to compile ES6 code (with extension ``.es6``) to ES5 code (with extension ``.js``).