### PR TITLE
Add setting to allow using custom separator for js concatenation

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -55,7 +55,9 @@ class Compressor(object):
 
     def compress_js(self, paths, templates=None, **kwargs):
         """Concatenate and compress JS files"""
-        js = self.concatenate(paths)
+        sep = settings.PIPELINE_JS_CONCAT_SEPARATOR
+
+        js = self.concatenate(paths, sep=sep)
         if templates:
             js = js + self.compile_templates(templates)
 
@@ -140,9 +142,9 @@ class Compressor(object):
             stylesheets.append(content)
         return '\n'.join(stylesheets)
 
-    def concatenate(self, paths):
+    def concatenate(self, paths, sep='\n'):
         """Concatenate together a list of files"""
-        return "\n".join([self.read_text(path) for path in paths])
+        return sep.join([self.read_text(path) for path in paths])
 
     def construct_asset_path(self, asset_path, css_path, output_filename, variant=None):
         """Return a rewritten asset URL for a stylesheet"""

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     'PIPELINE_TEMPLATE_SEPARATOR': "_",
 
     'PIPELINE_DISABLE_WRAPPER': False,
+    'PIPELINE_JS_CONCAT_SEPARATOR': '\n',
 
     'PIPELINE_CSSTIDY_BINARY': '/usr/bin/env csstidy',
     'PIPELINE_CSSTIDY_ARGUMENTS': '--template=highest',


### PR DESCRIPTION
Example.

File 1:

    (console.log(1))

File 2:

    (console.log(2))

File 3:

    (console.log(3))


Concatenated result:

    (console.log(1))
    (console.log(2))
    (console.log(3))

This js raises ` Uncaught TypeError: undefined is not a function` on second line.

Solution: use custom separator with `;` or `\n;\n`.