### PR TITLE
PipelineFinder.list should always return empty list

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -17,10 +17,7 @@ class PipelineFinder(BaseStorageFinder):
             return []
 
     def list(self, ignore_patterns):
-        if not settings.PIPELINE_ENABLED:
-            return super(PipelineFinder, self).list(ignore_patterns)
-        else:
-            return []
+        return []
 
 
 class ManifestFinder(BaseFinder):


### PR DESCRIPTION
Recent change of `PipelineFinder` breaks static collection with `PIPELINE_ENABLED = False` which is preferred for development.
`PipelineFinder.list` should still return empty list as it was in previous versions.

With standard list of finders:
```
STATICFILES_FINDERS = (
    'django.contrib.staticfiles.finders.FileSystemFinder',
    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
    'pipeline.finders.PipelineFinder',
    'pipeline.finders.CachedFileFinder',
)
```
and empty list from `PipelineFinder` everything works ok for both `PIPELINE_ENABLED` `True` and `False`.

Otherwise `return super(PipelineFinder, self).list(ignore_patterns)` leads to extra static file copies after each `collectstatic` invocation if current storage is "cached" (e.g. `STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'`).

At first iteration you got files:

```
css/common.css
css/common.e9dea09215fe.css
```

Then:
```
css/common.css
css/common.e9dea09215fe.css
css/common.e9dea09215fe.e9dea09215fe.css
```
and so on.