### PR TITLE
Let pipe lessc output to outfile rather than providing outfile arg due to lessc bug

### DIFF
--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -13,7 +13,8 @@ class LessCompiler(SubProcessCompiler):
         return filename.endswith('.less')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s %s %s %s" % (
+        # Pipe to file rather than provide outfile arg due to a bug in lessc
+        command = "%s %s %s > %s" % (
             settings.PIPELINE_LESS_BINARY,
             settings.PIPELINE_LESS_ARGUMENTS,
             infile,


### PR DESCRIPTION
Makes it work with bootstrap 3. See http://stackoverflow.com/questions/28475730/compiling-bootstrap-less-shows-errors-warnings