### PR TITLE
Strip STATIC_URL from start of path to avoid SuspiciousFileOperation during embed

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -159,6 +159,11 @@ class Compressor(object):
         font = ext in FONT_EXTS
         if not variant:
             return False
+
+        # strip STATIC_URL from path
+        if path.startswith(settings.STATIC_URL):
+            path = path[len(settings.STATIC_URL):]
+
         if not (re.search(settings.PIPELINE_EMBED_PATH, path.replace('\\', '/')) and self.storage.exists(path)):
             return False
         if ext not in EMBED_EXTS:
@@ -170,6 +175,11 @@ class Compressor(object):
     def with_data_uri(self, css):
         def datauri(match):
             path = match.group(1)
+
+            # strip STATIC_URL from path
+            if path.startswith(settings.STATIC_URL):
+                path = path[len(settings.STATIC_URL):]
+
             mime_type = self.mime_type(path)
             data = self.encoded_content(path)
             return "url(\"data:%s;charset=utf-8;base64,%s\")" % (mime_type, data)


### PR DESCRIPTION
With embed enabled, I was running into `SuspicousFileOperation` exceptions seemingly due to the `/static/` at the start of the asset path.

```
    content = compress(paths, **kwargs)
  File "/home/richard/work/DE/heartbeat/env/src/django-pipeline/pipeline/compressors/__init__.py", line 73, in compress_css
    css = self.concatenate_and_rewrite(paths, output_filename, variant)
  File "/home/richard/work/DE/heartbeat/env/src/django-pipeline/pipeline/compressors/__init__.py", line 139, in concatenate_and_rewrite
    content = re.sub(URL_DETECTOR, reconstruct, content)
  File "/home/richard/work/DE/heartbeat/env/lib/python2.7/re.py", line 151, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/home/richard/work/DE/heartbeat/env/src/django-pipeline/pipeline/compressors/__init__.py", line 135, in reconstruct
    output_filename, variant)
  File "/home/richard/work/DE/heartbeat/env/src/django-pipeline/pipeline/compressors/__init__.py", line 150, in construct_asset_path
    if self.embeddable(public_path, variant):
  File "/home/richard/work/DE/heartbeat/env/src/django-pipeline/pipeline/compressors/__init__.py", line 162, in embeddable
    if not (re.search(settings.PIPELINE_EMBED_PATH, path.replace('\\', '/')) and self.storage.exists(path)):
  File "/home/richard/work/DE/heartbeat/env/local/lib/python2.7/site-packages/django/core/files/storage.py", line 265, in exists
    return os.path.exists(self.path(name))
  File "/home/richard/work/DE/heartbeat/env/local/lib/python2.7/site-packages/django/contrib/staticfiles/storage.py", line 48, in path
    return super(StaticFilesStorage, self).path(name)
  File "/home/richard/work/DE/heartbeat/env/local/lib/python2.7/site-packages/django/core/files/storage.py", line 281, in path
    raise SuspiciousFileOperation("Attempted access to '%s' denied." % name)
django.core.exceptions.SuspiciousFileOperation: Attempted access to '/static/img/logo.png' denied.
```

This occurs regardless of whether I reference the asset using a relative url i.e. `img/logo.png` or an absolute url `/static/img/logo.png` in my LESS file.

I'm not sure if I'm doing something wrong, but stripping the `STATIC_URL` from paths prior to `storage.exists()` lookups  appears to resolve it.

