### PR TITLE
Add '#' to constant NON_REWRITEABLE_URL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ or just made Pipeline more awesome.
  * Denis V Seleznyov <code@xy2.ru>
  * DJ Sharkey <dj@newscred.com>
  * Edwin Lunando <edwinlunando@gmail.com>
+ * Eric Hamiter <ehamiter@gmail.com>
  * Evan Myller <eMyller@7ws.co>
  * Fabian Büchler <fabian.buechler@gmail.com>
  * Feanil Patel <feanil@edx.org>

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -16,7 +16,7 @@ from pipeline.exceptions import CompressorError
 
 URL_DETECTOR = r"""url\((['"]){0,1}\s*(.*?)["']{0,1}\)"""
 URL_REPLACER = r"""url\(__EMBED__(.+?)(\?\d+)?\)"""
-NON_REWRITABLE_URL = re.compile(r'^(http:|https:|data:|//)')
+NON_REWRITABLE_URL = re.compile(r'^(#|http:|https:|data:|//)')
 
 DEFAULT_TEMPLATE_FUNC = "template"
 TEMPLATE_FUNC = r"""var template = function(str){var fn = new Function('obj', 'var __p=[],print=function(){__p.push.apply(__p,arguments);};with(obj||{}){__p.push(\''+str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/<%=([\s\S]+?)%>/g,function(match,code){return "',"+code.replace(/\\'/g, "'")+",'";}).replace(/<%([\s\S]+?)%>/g,function(match,code){return "');"+code.replace(/\\'/g, "'").replace(/[\r\n\t]/g,' ')+"__p.push('";}).replace(/\r/g,'\\r').replace(/\n/g,'\\n').replace(/\t/g,'\\t')+"');}return __p.join('');");return fn;};"""

--- a/tests/assets/css/urls.css
+++ b/tests/assets/css/urls.css
@@ -21,4 +21,7 @@
 .no-protocol-url {
   background-image: url(//images/sprite-buttons.png);
 }
+.anchor-tag-url {
+  background-image: url(#image-gradient);
+}
 @font-face{src:url(../fonts/pipeline.eot);src:url(../fonts/pipeline.eot?#iefix) format('embedded-opentype'),url(../fonts/pipeline.woff) format('woff'),url(../fonts/pipeline.ttf) format('truetype');}

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -153,6 +153,9 @@ class CompressorTest(TestCase):
 .no-protocol-url {
   background-image: url(//images/sprite-buttons.png);
 }
+.anchor-tag-url {
+  background-image: url(#image-gradient);
+}
 @font-face{src:url(../pipeline/fonts/pipeline.eot);src:url(../pipeline/fonts/pipeline.eot?#iefix) format('embedded-opentype'),url(../pipeline/fonts/pipeline.woff) format('woff'),url(../pipeline/fonts/pipeline.ttf) format('truetype');}
 """, output)
 


### PR DESCRIPTION
Pipeline was ignoring HTML anchor tags as valid URLs, and would erroneously prepend a relative directory path to the anchor tag.

This fix adds the octothorpe (#) to the constant NON_REWRITEABLE_URL to allow the anchor tag to be ignored as a valid URL link.