### PR TITLE
Staticfiles compiler mixin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ or just made Pipeline more awesome.
  * Jared Scott <jscott@convertro.com>
  * Jaromir Fojtu <jaromir.fojtu@gmail.com>
  * Jon Dufresne <jon.dufresne@gmail.com>
+ * Jonas Lundberg <jonas@5monkeys.se>
  * Josh Braegger <rckclmbr@gmail.com>
  * Joshua Kehn <josh@kehn.us>
  * Julien Hartmann <julien@etherdream.org>

--- a/docs/compilers.rst
+++ b/docs/compilers.rst
@@ -173,6 +173,29 @@ To use it add this to your ``PIPELINE_COMPILERS`` ::
   Defaults to ``''``.
 
 
+.. _StaticFilesCompilerMixin:
+
+Static files compiler mixin
+===========================
+
+When using compilers together with a remote storage, like S3,
+you need to extend the compiler of choice to use staticfiles instead of the remote storage.
+
+To do so, you just have to create your own compiler class that inherits from
+``pipeline.compilers.StaticFilesCompilerMixin`` and your desired compiler.
+
+Example
+-------
+
+A custom less compiler extended with staticfiles usage ::
+
+  from pipeline.compilers import StaticFilesCompilerMixin
+  from pipeline.compilers.less import LessCompiler
+
+  class LocalLessCompiler(StaticFilesCompilerMixin, LessCompiler):
+      pass
+
+
 Write your own compiler class
 =============================
 

--- a/docs/storages.rst
+++ b/docs/storages.rst
@@ -95,6 +95,10 @@ unless you don't have access to the local filesystem in which case you should us
   class S3PipelineCachedStorage(PipelineMixin, CachedFilesMixin, S3BotoStorage):
       pass
 
+.. note::
+  When using custom storage in combination with compilers you may also need to use ``StaticFilesCompilerMixin``
+  (see StaticFilesCompilerMixin_ for more details).
+
 
 Using Pipeline with Bower
 =========================

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -34,10 +34,7 @@ class Compiler(object):
                 compiler = compiler(verbose=self.verbose, storage=self.storage)
                 if compiler.match_file(input_path):
                     output_path = self.output_path(input_path, compiler.output_extension)
-                    try:
-                        infile = self.storage.path(input_path)
-                    except NotImplementedError:
-                        infile = finders.find(input_path)
+                    infile = compiler.path(input_path)
                     outfile = self.output_path(infile, compiler.output_extension)
                     outdated = compiler.is_outdated(input_path, output_path)
                     compiler.compile_file(quote(infile), quote(outfile),
@@ -70,6 +67,12 @@ class CompilerBase(object):
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         raise NotImplementedError
+
+    def path(self, name):
+        try:
+            return self.storage.path(name)
+        except NotImplementedError:
+            return finders.find(name)
 
     def save_file(self, path, content):
         return self.storage.save(path, ContentFile(smart_str(content)))

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -39,6 +39,8 @@ class Compiler(object):
                     outdated = compiler.is_outdated(input_path, output_path)
                     compiler.compile_file(quote(infile), quote(outfile),
                         outdated=outdated, force=force)
+                    if hasattr(compiler, 'post_process'):
+                        compiler.post_process(outfile, name=output_path)
                     return output_path
             else:
                 return input_path


### PR DESCRIPTION
Extends #409 and fixes #403

* Moving infile path lookup to `CompilerBase` to enable compiler class level overrides.
* Adding a new `StaticFilesCompilerMixin` solving the problem when using remote storages + cache/manifest together with compilers.

Mimics the storage mixin usage...

```
class S3PipelineCachedStorage(PipelineMixin, CachedFilesMixin, S3BotoStorage):
    pass

class LocalLessCompiler(StaticFilesCompilerMixin, LessCompiler):
    pass
```