### PR TITLE
django.utils.importlib removed in Django 1.9.

### DIFF
--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import sys
 import mimetypes
 import posixpath
 
@@ -8,10 +9,46 @@ try:
 except ImportError:
     from urllib import quote
 
-from django.utils import importlib
+from django.utils import six
 from django.utils.encoding import smart_str
 
 from pipeline.conf import settings
+
+
+if six.PY3:
+    from importlib import import_module
+else:
+    def _resolve_name(name, package, level):
+        """Return the absolute name of the module to be imported."""
+        if not hasattr(package, 'rindex'):
+            raise ValueError("'package' not set to a string")
+        dot = len(package)
+        for x in range(level, 1, -1):
+            try:
+                dot = package.rindex('.', 0, dot)
+            except ValueError:
+                raise ValueError("attempted relative import beyond top-level package")
+        return "%s.%s" % (package[:dot], name)
+
+    def import_module(name, package=None):
+        """Import a module.
+
+        The 'package' argument is required when performing a relative import. It
+        specifies the package to use as the anchor point from which to resolve the
+        relative import to an absolute import.
+
+        """
+        if name.startswith('.'):
+            if not package:
+                raise TypeError("relative imports require the 'package' argument")
+            level = 0
+            for character in name:
+                if character != '.':
+                    break
+                level += 1
+            name = _resolve_name(name[level:], package, level)
+        __import__(name)
+        return sys.modules[name]
 
 
 def to_class(class_str):
@@ -20,7 +57,7 @@ def to_class(class_str):
 
     module_bits = class_str.split('.')
     module_path, class_name = '.'.join(module_bits[:-1]), module_bits[-1]
-    module = importlib.import_module(module_path)
+    module = import_module(module_path)
     return getattr(module, class_name, None)
 
 


### PR DESCRIPTION
Hi!

django.utils.importlib removed in Django 1.9: https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9

