### PR TITLE
Fix for wrapping javascript code.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,3 +93,4 @@ or just made Pipeline more awesome.
  * Wictor Olseryd <wictor@olseryd.se>
  * Zachary Kazanski <kazanski.zachary@gmail.com>
  * Zenobius Jiricek <zenobius.jiricek@gmail.com>
+ * Alex Gavrișco <alexandr@gavrisco.com>

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -253,7 +253,9 @@ Wrapped javascript output
 
 All javascript output is wrapped in an anonymous function : ::
 
-  (function(){ ... })();
+  (function(){ 
+    //JS output...
+  })();
 
 This safety wrapper, make it difficult to pollute the global namespace by accident and improve performance.
 

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -60,7 +60,7 @@ class Compressor(object):
             js = js + self.compile_templates(templates)
 
         if not settings.PIPELINE_DISABLE_WRAPPER:
-            js = "(function() { %s }).call(this);" % js
+            js = "(function() {\n%s\n}).call(this);" % js
 
         compressor = self.js_compressor
         if compressor:


### PR DESCRIPTION
Fixed bug when wrapped javascript code ends with one-line comment.
Obviously, this causes syntax error.