### PR TITLE
Add ng annotate compiler.

### DIFF
--- a/pipeline/compilers/ngannotate.py
+++ b/pipeline/compilers/ngannotate.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+from pipeline.conf import settings
+from pipeline.compilers import SubProcessCompiler
+
+
+class NgAnnnotateCompiler(SubProcessCompiler):
+    output_extension = 'js'
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return  # File doesn't need to be recompiled
+        command = "%s %s %s -o %s" % (
+            settings.PIPELINE_NG_ANNOTATE_BINARY,
+            settings.PIPELINE_NG_ANNOTATE_ARGUMENTS,
+            infile,
+            outfile
+        )
+        return self.execute_command(command)

--- a/pipeline/compilers/ngannotate.py
+++ b/pipeline/compilers/ngannotate.py
@@ -7,6 +7,9 @@ from pipeline.compilers import SubProcessCompiler
 class NgAnnnotateCompiler(SubProcessCompiler):
     output_extension = 'js'
 
+    def match_file(self, path):
+        return path.endswith('.js')
+
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # File doesn't need to be recompiled

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -63,6 +63,9 @@ DEFAULTS = {
     'PIPELINE_LESS_BINARY': '/usr/bin/env lessc',
     'PIPELINE_LESS_ARGUMENTS': '',
 
+    'PIPELINE_NG_ANNOTATE_BINARY': '/usr/bin/env ng-annotate',
+    'PIPELINE_NG_ANNOTATE_ARGUMENTS': '--add',
+
     'PIPELINE_MIMETYPES': (
         (b'text/coffeescript', '.coffee'),
         (b'text/less', '.less'),


### PR DESCRIPTION
This adds ng-annotate as a compiler, assuming the user has ng-annotate available. This allows people using django-pipeline to minify their code to make the Angular code minification-safe first.