### PR TITLE
Update ignore patterns list in built in finder for Bower friendliness

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -93,6 +93,7 @@ class FileSystemFinder(PatternFilterMixin, FileSystemFinder):
     ignore_patterns = [
         '*.js',
         '*.css',
+        '*.json',
         '*.less',
         '*.scss',
         '*.styl',
@@ -114,4 +115,5 @@ class FileSystemFinder(PatternFilterMixin, FileSystemFinder):
         'Makefile*',
         'Gemfile*',
         'node_modules',
+        'bower_components',
     ]


### PR DESCRIPTION
Inside my project's main static directory I have a `bower.json` file like so:
```
{
  "name": "project",
  "version": "0.0.1",
  "homepage": "http://dirtymonkey.co.uk",
  "authors": [
    "Matt Deacalion Stevens <matt@dirtymonkey.co.uk>"
  ],
  "private": true,
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "bourbon": "~4.2.3",
    "jquery": "~2.1.4"
  }
}
```

Inside my static directory I then use `bower install` to pull down all my dependencies. I've added a few ignore entries to stop these Bower fragments from being collected.