### PR TITLE
Change smart_str to smart_bytes or smart_text

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -81,6 +81,8 @@ class CompilerBase(object):
         return content
 
     def is_outdated(self, infile, outfile):
+        if not self.storage.exists(outfile):
+            return True
         try:
             return self.storage.modified_time(infile) > self.storage.modified_time(outfile)
         except (OSError, NotImplementedError):

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -10,7 +10,7 @@ except ImportError:
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.base import ContentFile
-from django.utils.encoding import smart_str, smart_bytes
+from django.utils.encoding import smart_bytes
 
 from pipeline.conf import settings
 from pipeline.exceptions import CompilerError
@@ -72,7 +72,7 @@ class CompilerBase(object):
         raise NotImplementedError
 
     def save_file(self, path, content):
-        return self.storage.save(path, ContentFile(smart_str(content)))
+        return self.storage.save(path, ContentFile(smart_bytes(content)))
 
     def read_file(self, path):
         file = self.storage.open(path, 'rb')

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.contrib.staticfiles.finders import find
 from django.core.files.base import ContentFile
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
 
 from pipeline.compilers import Compiler
 from pipeline.compressors import Compressor
@@ -115,7 +115,7 @@ class Packager(object):
         return self.compressor.compile_templates(package.templates)
 
     def save_file(self, path, content):
-        return self.storage.save(path, ContentFile(smart_str(content)))
+        return self.storage.save(path, ContentFile(smart_bytes(content)))
 
     def create_packages(self, config):
         packages = {}

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from urllib import quote
 
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_text
 
 from pipeline.conf import settings
 
@@ -27,7 +27,7 @@ def to_class(class_str):
 def filepath_to_uri(path):
     if path is None:
         return path
-    return quote(smart_str(path).replace("\\", "/"), safe="/~!*()'#?")
+    return quote(smart_text(path).replace("\\", "/"), safe="/~!*()'#?")
 
 
 def guess_type(path, default=None):
@@ -36,7 +36,7 @@ def guess_type(path, default=None):
     mimetype, _ = mimetypes.guess_type(path)
     if not mimetype:
         return default
-    return smart_str(mimetype)
+    return smart_text(mimetype)
 
 
 def relpath(path, start=posixpath.curdir):


### PR DESCRIPTION
In python3 smart_str is alias to smart_text and that breaks save_file methods. smart_bytes should be used instead. In utils.py, smart_text is more appropriate.