### PR TITLE
add templates to test pipeline

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -118,3 +118,17 @@ PIPELINE_JS = {
         }
     }
 }
+
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': TEMPLATE_DIRS,
+    },
+    {
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
+        'APP_DIRS': True,
+        'DIRS': TEMPLATE_DIRS,
+    }
+]


### PR DESCRIPTION
warning in 1.9

RemovedInDjango110Warning: You haven't defined a TEMPLATES setting. You must do so before upgrading to Django 1.10. Otherwise Django will be unable to load templates.