### PR TITLE
Remove useless requirement "futures" on Python 3.2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,12 @@
 import io
 
 from setuptools import setup, find_packages
+import sys
 
 install_requires = []
-try:
-    from concurrent import futures
-except ImportError:
-    futures = None
+if (sys.version_info[0], sys.version_info[1]) < (3, 2):
     install_requires.append('futures>=2.1.3')
+
 setup(
     name='django-pipeline',
     version='1.5.2',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,12 @@ import io
 
 from setuptools import setup, find_packages
 
-
+install_requires = []
+try:
+    from concurrent import futures
+except ImportError:
+    futures = None
+    install_requires.append('futures>=2.1.3')
 setup(
     name='django-pipeline',
     version='1.5.2',
@@ -16,9 +21,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests', 'tests.tests']),
     zip_safe=False,
-    install_requires=[
-        'futures>=2.1.3',
-    ],
+    install_requires=install_requires,
     include_package_data=True,
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
futures is useless on Python 3.2+ as it is bundled with the standard lib and is not compatible with Python 3 (leads to errors when creating Debian packages, among some other problems)