### PR TITLE
Added the ability to inline JS and CSS

### DIFF
--- a/pipeline/templates/pipeline/inline_css.html
+++ b/pipeline/templates/pipeline/inline_css.html
@@ -1,0 +1,3 @@
+<style type="{{ type }}"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %}>
+  {{ source|safe }}
+</style>

--- a/pipeline/templates/pipeline/inline_css.jinja
+++ b/pipeline/templates/pipeline/inline_css.jinja
@@ -1,0 +1,3 @@
+<style type="{{ type }}"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %}>
+  {{ source|safe }}
+</style>


### PR DESCRIPTION
Adds the ability to do inline JS/CSS with pipeline by adding ‘inline’
to the template tag, aka:

{% javascript 'head_js' 'inline' %}

This pull request is for the aim of opening the discussion around what needs to be done to enable inline embedding of Javascript and CSS directly into the page.  This is useful when optimizing network requests for styles/scripts only relevant to a single page.