### PR TITLE
Prevent multiple collect in jinja template tags

### DIFF
--- a/pipeline/collector.py
+++ b/pipeline/collector.py
@@ -11,7 +11,8 @@ from pipeline.finders import PipelineFinder
 
 
 class Collector(object):
-    request = None
+
+    env = None
 
     def __init__(self, storage=None):
         if storage is None:
@@ -26,10 +27,10 @@ class Collector(object):
         for d in dirs:
             self.clear(os.path.join(path, d))
 
-    def collect(self, request=None):
-        if self.request and self.request is request:
+    def collect(self, env=None):
+        if self.env and self.env is env:
             return
-        self.request = request
+        self.env = env
         found_files = OrderedDict()
         for finder in finders.get_finders():
             # Ignore our finder to avoid looping

--- a/pipeline/templatetags/ext.py
+++ b/pipeline/templatetags/ext.py
@@ -13,6 +13,9 @@ from .pipeline import PipelineMixin
 class PipelineExtension(PipelineMixin, Extension):
     tags = set(['stylesheet', 'javascript'])
 
+    def get_collector_env(self):
+        return self.environment
+
     def parse(self, parser):
         tag = next(parser.stream)
 


### PR DESCRIPTION
This issue has been already fixed for Django templates — https://github.com/cyberdelia/django-pipeline/pull/455
But there is no `request` inside jinja extensions. So we need to make `PipelineExtension` more generic.